### PR TITLE
Added Joomla Component Builder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ jsconfig.json
 .php_cs.dist
 .php_cs
 .gitkeep
+.idea
 
 # Composer
 composer.phar

--- a/readme.md
+++ b/readme.md
@@ -86,6 +86,7 @@ To browse the whole catalog of extensions, please, visit the extension directory
 - [anibalsanchez/extly-buildfiles-for-joomla](https://github.com/anibalsanchez/extly-buildfiles-for-joomla) - Webpack-automated build files for Joomla! extensions. Supports all extensions types + JavaScript Apps (Angular, React, Vue or VanillaJS with Laravel Mix) + Node/NPM + Composer.
 - [joomla-extensions/weblinks](https://github.com/joomla-extensions/weblinks) - This repo is meant to hold the decoupled com_weblinks component and related code.
 - [anibalsanchez/VSCode-Joomla-Snippets](https://github.com/anibalsanchez/VSCode-Joomla-Snippets) - Extension for Visual Studio.
+- [vdm-io/Joomla-Component-Builder](https://github.com/vdm-io/Joomla-Component-Builder) - Builds complex Joomla! extensions in Joomla!
 
 #### Template Frameworks
 


### PR DESCRIPTION
Added Joomla Component Builder to the list of Extension Development tools. Also updated ignore to include .idea for PHPStorm.